### PR TITLE
Reject point spans

### DIFF
--- a/src/Calligraphy/Compat/Lib.hs
+++ b/src/Calligraphy/Compat/Lib.hs
@@ -13,6 +13,7 @@ module Calligraphy.Compat.Lib
     isDerivingNode,
     showAnns,
     spanSpans,
+    isPointSpan,
   )
 where
 
@@ -109,3 +110,6 @@ spanSpans sp1 sp2 =
         (realSrcSpanEnd sp1)
         (realSrcSpanEnd sp2)
     )
+
+isPointSpan :: Span -> Bool
+isPointSpan sp = realSrcSpanEnd sp <= realSrcSpanStart sp


### PR DESCRIPTION
Fixes #2 

I think it's safe to outright reject all nodes that have a point span (zero width). The LexTree doesn't (currently) support them, and we reject generated code in other places as well. Nothing but headaches.