### PR TITLE
Option to show just the module graph

### DIFF
--- a/calligraphy.cabal
+++ b/calligraphy.cabal
@@ -44,9 +44,9 @@ library
     Calligraphy.Compat.Debug
     Calligraphy.Compat.GHC
     Calligraphy.Compat.Lib
-    Calligraphy.Phases.Collapse
     Calligraphy.Phases.DependencyFilter
     Calligraphy.Phases.EdgeCleanup
+    Calligraphy.Phases.NodeFilter
     Calligraphy.Phases.Parse
     Calligraphy.Phases.Render
     Calligraphy.Phases.Search

--- a/src/Calligraphy.hs
+++ b/src/Calligraphy.hs
@@ -55,7 +55,8 @@ mainWithConfig AppConfig {..} = do
   let cgCleaned = cleanupEdges edgeFilterConfig cgDependencyFiltered
   debug dumpFinal $ ppCallGraph cgCleaned
 
-  let txt = runPrinter $ render renderConfig cgCleaned
+  let renderConfig' = renderConfig {clusterModules = clusterModules renderConfig && not (collapseModules nodeFilterConfig)}
+      txt = runPrinter $ render renderConfig' cgCleaned
 
   output outputConfig txt
 

--- a/src/Calligraphy/Phases/Render.hs
+++ b/src/Calligraphy/Phases/Render.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE RecordWildCards #-}
 
 -- | Rendering takes a callgraph, and produces a dot file
-module Calligraphy.Phases.Render (render, pRenderConfig, RenderConfig) where
+module Calligraphy.Phases.Render (render, pRenderConfig, RenderConfig (..)) where
 
 import Calligraphy.Util.Printer
 import Calligraphy.Util.Types


### PR DESCRIPTION
Fixes #4 

This is an initial stab at allowing just a high-level overview of the module graph with `--collapse-modules`.

- [ ] There's some places that don't handle ModuleDecl yet, not sure why CI doesn't give a warning for those

```
calligraphy 'src/*' -p out.png --collapse-modules
```
![out](https://user-images.githubusercontent.com/3593851/165464887-1033b6be-ff29-408e-9879-b2fedb7ff897.png)

I thought it would be nice to hide the entire functionality behind a single flag, but now that I've written it, I think I might prefer https://github.com/jonascarpay/calligraphy/issues/4#issuecomment-1110617467. It requires more flags to get the same result as the above graph, but it would be more flexible, and integrates nicely and predictably with the existing logic.

One other possible design:
  - Add a top-level node for each module, with all declarations as its children
  - Add a dissolve phase that, for each node type, adds a `--dissolve-*` option to remove that node type but keep its children. This would be turned on by default for modules to get the original behavior. This should be enough to be able to replicate the above graph.
  - Additionally, if dissolving happens after collapsing, and only affects non-empty nodes (`--keep-empty`? on by default?), you would only need `--collapse-modules`.

I'm not sure if dissolving would ever be useful outside of modules, though. If not, it's just a roundabout way of achieving  https://github.com/jonascarpay/calligraphy/issues/4#issuecomment-1110617467