### PR TITLE
Remove vestigial MonadPrint class

### DIFF
--- a/src/Calligraphy/Phases/Render.hs
+++ b/src/Calligraphy/Phases/Render.hs
@@ -90,7 +90,8 @@ render RenderConfig {..} (CallGraph modules calls types) = do
       where
         nodeStyle :: String
         nodeStyle =
-          show . intercalate ", "
+          show
+            . intercalate ", "
             . consIf (typ == RecDecl) "rounded"
             . consIf (not exported) "dashed"
             . cons "filled"
@@ -103,7 +104,7 @@ consIf :: Bool -> a -> [a] -> [a]
 consIf True = (:)
 consIf False = flip const
 
-consManyIf :: Foldable f => Bool -> f a -> [a] -> [a]
+consManyIf :: Bool -> [a] -> [a] -> [a]
 consManyIf True fs as = foldr (:) as fs
 consManyIf False _ as = as
 
@@ -114,7 +115,7 @@ nodeShape RecDecl = "box"
 nodeShape ClassDecl = "house"
 nodeShape ValueDecl = "ellipse"
 
-edge :: MonadPrint m => Key -> Key -> Style -> m ()
+edge :: Key -> Key -> Style -> Printer ()
 edge (Key from) (Key to) sty = strLn $ show from <> " -> " <> show to <> " " <> style sty
 
 (.=) :: String -> String -> (String, String)

--- a/src/Calligraphy/Util/Printer.hs
+++ b/src/Calligraphy/Util/Printer.hs
@@ -1,17 +1,28 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Calligraphy.Util.Printer where
+module Calligraphy.Util.Printer
+  ( Printer,
+    Prints,
+    runPrinter,
+    indent,
+    brack,
+    strLn,
+    textLn,
+    showLn,
+  )
+where
 
 import Control.Monad.RWS
-import Control.Monad.State
 import Data.Foldable
 import Data.Text (Text)
 import qualified Data.Text.Lazy as TL
 import Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder as TB
 
-newtype Printer a = Printer {unPrinter :: RWS Int () Builder a}
+-- | An monadic interface to a fairly primitive line printer.
+-- It maintains an indentation level, and provides efficient concatenation through 'Builder', and that's it.
+newtype Printer a = Printer {_unPrinter :: RWS Int () Builder a}
   deriving newtype (Functor, Applicative, Monad)
   deriving (Semigroup, Monoid) via (Ap Printer a)
 
@@ -20,36 +31,30 @@ type Prints a = a -> Printer ()
 runPrinter :: Printer () -> Text
 runPrinter (Printer p) = TL.toStrict . TB.toLazyText . fst $ execRWS p 0 mempty
 
-class Monad m => MonadPrint m where
-  line :: Builder -> m ()
-  indent :: m a -> m a
+{-# INLINE indent #-}
+indent :: Printer a -> Printer a
+indent (Printer p) = Printer $ local (+ 4) p
 
-instance MonadPrint Printer where
-  {-# INLINE indent #-}
-  indent (Printer p) = Printer $ local (+ 4) p
-
-  {-# INLINE line #-}
-  line t = Printer $ do
-    n <- ask
-    modify $
-      flip mappend $ fold (replicate n (TB.singleton ' ')) <> t <> TB.singleton '\n'
-
-instance MonadPrint m => MonadPrint (StateT s m) where
-  line = lift . line
-  indent (StateT m) = StateT $ indent . m
+{-# INLINE line #-}
+line :: Builder -> Printer ()
+line t = Printer $ do
+  n <- ask
+  modify $
+    flip mappend $
+      fold (replicate n (TB.singleton ' ')) <> t <> TB.singleton '\n'
 
 {-# INLINE brack #-}
-brack :: MonadPrint m => String -> String -> m a -> m a
+brack :: String -> String -> Printer a -> Printer a
 brack pre post inner = strLn pre *> indent inner <* strLn post
 
 {-# INLINE strLn #-}
-strLn :: MonadPrint m => String -> m ()
+strLn :: String -> Printer ()
 strLn = line . TB.fromString
 
 {-# INLINE textLn #-}
-textLn :: MonadPrint m => Text -> m ()
+textLn :: Text -> Printer ()
 textLn = line . TB.fromText
 
 {-# INLINE showLn #-}
-showLn :: (MonadPrint m, Show a) => a -> m ()
+showLn :: (Show a) => a -> Printer ()
 showLn = strLn . show


### PR DESCRIPTION
`Printer` is never actually used in a transformer stack (anymore), so there's no need to be this general.