### PR TITLE
Untangle rendering

### DIFF
--- a/calligraphy.cabal
+++ b/calligraphy.cabal
@@ -54,7 +54,8 @@ library
     Calligraphy.Phases.EdgeCleanup
     Calligraphy.Phases.NodeFilter
     Calligraphy.Phases.Parse
-    Calligraphy.Phases.Render
+    Calligraphy.Phases.Render.Common
+    Calligraphy.Phases.Render.GraphViz
     Calligraphy.Phases.Search
     Calligraphy.Util.Lens
     Calligraphy.Util.LexTree

--- a/src/Calligraphy/Phases/Render/Common.hs
+++ b/src/Calligraphy/Phases/Render/Common.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE RecordWildCards #-}
+
+-- | Prepare the call graph for rendering
+module Calligraphy.Phases.Render.Common
+  ( RenderConfig (..),
+    pRenderConfig,
+    renderGraph,
+    RenderError,
+    ppRenderError,
+    ID,
+    RenderGraph (..),
+    RenderModule (..),
+    RenderNode (..),
+    if',
+  )
+where
+
+import Calligraphy.Util.Printer (Prints, strLn)
+import Calligraphy.Util.Types (CallGraph (..), Decl (..), DeclType, GHCKey (unGHCKey), Key (..), Loc (..), Module (..))
+import Control.Applicative ((<|>))
+import Data.Bifunctor (bimap)
+import qualified Data.EnumSet as EnumSet
+import Data.List.NonEmpty (NonEmpty, nonEmpty)
+import Data.Maybe (catMaybes, mapMaybe)
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Tree (Tree)
+import Options.Applicative (Parser, flag, flag', help, long)
+
+data RenderConfig = RenderConfig
+  { showCalls :: Bool,
+    showTypes :: Bool,
+    showKey :: Bool,
+    showGHCKeys :: Bool,
+    showModulePath :: Bool,
+    locMode :: LocMode,
+    clusterModules :: Bool
+  }
+
+pRenderConfig :: Parser RenderConfig
+pRenderConfig =
+  RenderConfig
+    <$> flag True False (long "hide-calls" <> help "Don't show call arrows")
+    <*> flag True False (long "hide-types" <> help "Don't show type arrows")
+    <*> flag False True (long "show-key" <> help "Show internal keys with identifiers. Useful for debugging.")
+    <*> flag False True (long "show-ghc-key" <> help "Show GHC keys with identifiers. Useful for debugging.")
+    <*> flag False True (long "show-module-path" <> help "Show a module's filepath instead of its name")
+    <*> pLocMode
+    <*> flag True False (long "no-cluster-modules" <> help "Don't draw modules as a cluster.")
+
+-- | A directly printable string uniquely identifying a declaration.
+type ID = String
+
+-- | A representation of the call graph that's convenient for rendering.
+-- Structurally, it's the same as 'CallGraph', in that it's a tree of nodes and a flat list of edges.
+-- The differences is that as much of the non-backend-specific preprocessing has already been taken care of.
+--   - Nodes and modules have a unique string ID
+--   - Nodes and modules contain their desired label
+--   - Render roots are guaranteed to be non-empty
+--   - Set of calls and types are empty on --hide-{calls, types}
+--   - Modules are flattened depending on --no-cluster-modules
+data RenderGraph = RenderGraph
+  { renderRoots :: Either (NonEmpty RenderModule) (NonEmpty (Tree RenderNode)), -- Right if --no-cluster-modules
+    callEdges :: Set (ID, ID), -- empty if --hide-calls
+    typeEdges :: Set (ID, ID) -- empty if --hide-types
+  }
+
+data RenderModule = RenderModule
+  { moduleLabel :: String,
+    moduleId :: ID,
+    moduleDecls :: NonEmpty (Tree RenderNode)
+  }
+
+data RenderNode = RenderNode
+  { nodeId :: ID,
+    nodeType :: DeclType,
+    nodeLabelLines :: [String],
+    nodeExported :: Bool
+  }
+
+data LocMode = Hide | Line | LineCol
+
+data RenderError = EmptyGraph
+
+ppRenderError :: Prints RenderError
+ppRenderError EmptyGraph = strLn "Output graph is empty"
+
+renderGraph :: RenderConfig -> CallGraph -> Either RenderError RenderGraph
+renderGraph
+  RenderConfig {..}
+  (CallGraph modules calls types) =
+    case nonEmpty (mapMaybe (uncurry mkModule) (zip modules [0 ..])) of
+      Nothing -> Left EmptyGraph
+      Just neModules ->
+        pure $
+          RenderGraph
+            (if clusterModules then Left neModules else Right (neModules >>= moduleDecls))
+            (if showCalls then Set.map (bimap keyId keyId) calls else Set.empty)
+            (if showTypes then Set.map (bimap keyId keyId) types else Set.empty)
+    where
+      keyId :: Key -> ID
+      keyId (Key k) = "node_" <> show k
+
+      mkModule :: Module -> Int -> Maybe RenderModule
+      mkModule (Module name path decls) ix =
+        (\ne -> RenderModule label ("module_" <> show ix) (fmap mkNode <$> ne)) <$> nonEmpty decls
+        where
+          label
+            | showModulePath = path
+            | otherwise = name
+
+      mkNode :: Decl -> RenderNode
+      mkNode (Decl name key ghcKeys x t loc) = RenderNode (keyId key) t (catMaybes lbls) x
+        where
+          lbls =
+            [ pure name,
+              if' showKey $ show (unKey key),
+              if' showGHCKeys $ "GHC Keys: " <> (unwords . fmap (show . unGHCKey) . EnumSet.toList $ ghcKeys),
+              case locMode of
+                Hide -> Nothing
+                Line -> Just ('L' : show (locLine loc))
+                LineCol -> Just (show loc)
+            ]
+
+pLocMode :: Parser LocMode
+pLocMode =
+  flag' Line (long "show-line" <> help "Show line numbers")
+    <|> flag' LineCol (long "show-line-col" <> help "Show line and column numbers")
+    <|> pure Hide
+
+-- TODO this needs to be moved to an appropriate Util/Lib module
+if' :: Bool -> a -> Maybe a
+if' True a = Just a
+if' False _ = Nothing

--- a/src/Calligraphy/Phases/Render/GraphViz.hs
+++ b/src/Calligraphy/Phases/Render/GraphViz.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-- | Rendering takes a callgraph, and produces a dot file
+module Calligraphy.Phases.Render.GraphViz
+  ( GraphVizConfig,
+    pGraphVizConfig,
+    renderGraphViz,
+  )
+where
+
+import Calligraphy.Phases.Render.Common
+import Calligraphy.Util.Printer
+import Calligraphy.Util.Types
+import Control.Monad (forM_, unless)
+import Data.List (intercalate)
+import Data.Maybe (catMaybes)
+import Data.Tree (Tree (..))
+import Options.Applicative hiding (style)
+import Text.Show (showListWith)
+
+data GraphVizConfig = GraphVizConfig
+  { showChildArrowhead :: Bool,
+    clusterGroups :: Bool,
+    splines :: Bool,
+    reverseDependencyRank :: Bool
+  }
+
+pGraphVizConfig :: Parser GraphVizConfig
+pGraphVizConfig =
+  GraphVizConfig
+    <$> flag False True (long "show-child-arrowhead" <> help "Put an arrowhead at the end of a parent-child edge")
+    <*> flag True False (long "no-cluster-trees" <> help "Don't draw definition trees as a cluster.")
+    <*> flag True False (long "no-splines" <> help "Render arrows as straight lines instead of splines")
+    <*> flag False True (long "reverse-dependency-rank" <> help "Make dependencies have lower rank than the dependee, i.e. show dependencies above their parent.")
+
+renderGraphViz :: GraphVizConfig -> Prints RenderGraph
+renderGraphViz GraphVizConfig {..} (RenderGraph roots calls types) = do
+  brack "digraph calligraphy {" "}" $ do
+    unless splines $ textLn "splines=false;"
+    textLn "node [style=filled fillcolor=\"#ffffffcf\"];"
+    textLn "graph [outputorder=edgesfirst];"
+    case roots of
+      Left modules -> mapM_ printModule modules
+      Right trees -> mapM_ printTree trees
+    forM_ calls $ \(caller, callee) ->
+      if reverseDependencyRank
+        then edge caller callee []
+        else edge callee caller ["dir" .= "back"]
+    forM_ types $ \(caller, callee) ->
+      if reverseDependencyRank
+        then edge caller callee ["style" .= "dotted"]
+        else edge callee caller ["style" .= "dotted", "dir" .= "back"]
+  where
+    printTree :: Prints (Tree RenderNode)
+    printTree (Node nodeInfo children) = wrapCluster $ do
+      printNode nodeInfo
+      forM_ children $ \child@(Node childInfo _) -> do
+        printTree child
+        edge (nodeId nodeInfo) (nodeId childInfo) . catMaybes $
+          [ pure ("style" .= "dashed"),
+            if' (not showChildArrowhead) ("arrowhead" .= "none")
+          ]
+      where
+        wrapCluster inner
+          | clusterGroups && not (null children) = brack ("subgraph cluster_" <> nodeId nodeInfo <> " {") "}" $ do
+              textLn "style=invis;"
+              inner
+          | otherwise = inner
+
+    printModule :: Prints RenderModule
+    printModule (RenderModule lbl modId trees) =
+      brack ("subgraph cluster_module_" <> modId <> " {") "}" $ do
+        strLn $ "label=" <> show lbl <> ";"
+        forM_ trees printTree
+
+    printNode :: Prints RenderNode
+    printNode (RenderNode nId typ lbll exported) =
+      strLn $ nId <> " " <> renderAttrs attrs
+      where
+        attrs =
+          [ "label" .= ("\"" <> intercalate "\n" lbll <> "\""),
+            "shape" .= nodeShape typ,
+            "style" .= nodeStyle
+          ]
+        nodeStyle =
+          show . intercalate ", " . catMaybes $
+            [ if' (typ == RecDecl) "rounded",
+              if' (not exported) "dashed",
+              pure "filled"
+            ]
+
+nodeShape :: DeclType -> String
+nodeShape DataDecl = "octagon"
+nodeShape ConDecl = "box"
+nodeShape RecDecl = "box"
+nodeShape ClassDecl = "house"
+nodeShape ValueDecl = "ellipse"
+
+edge :: ID -> ID -> Attributes -> Printer ()
+edge from to attrs = strLn $ show from <> " -> " <> show to <> " " <> renderAttrs attrs
+
+(.=) :: String -> String -> (String, String)
+(.=) = (,)
+
+renderAttrs :: Attributes -> String
+renderAttrs attrs = showListWith (\(key, val) -> showString key . showChar '=' . showString val) attrs ";"
+
+type Attributes = [(String, String)]

--- a/src/Calligraphy/Util/Types.hs
+++ b/src/Calligraphy/Util/Types.hs
@@ -97,7 +97,10 @@ forestT :: Traversal (Forest a) (Forest b) a b
 forestT = traverse . traverse
 
 rekeyCalls :: (Enum a, Ord b) => EnumMap a b -> Set (a, a) -> Set (b, b)
-rekeyCalls m = foldr (maybe id Set.insert . bitraverse (flip EnumMap.lookup m) (flip EnumMap.lookup m)) mempty
+rekeyCalls m =
+  foldr
+    (maybe id Set.insert . bitraverse (flip EnumMap.lookup m) (flip EnumMap.lookup m))
+    mempty
 
 ppCallGraph :: Prints CallGraph
 ppCallGraph (CallGraph modules _ _) = forM_ modules $ \(Module modName modPath forest) -> do

--- a/test/Test/Reference.dot
+++ b/test/Test/Reference.dot
@@ -1,151 +1,136 @@
 digraph calligraphy {
     node [style=filled fillcolor="#ffffffcf"];
     graph [outputorder=edgesfirst];
-    subgraph cluster_module_0 {
+    subgraph cluster_module_module_0 {
         label="Test.Reference";
-        subgraph cluster_0_0 {
+        subgraph cluster_node_0 {
             style=invis;
-            0 [label="Class",shape=house,style="filled"];
-            1 [label="CDF",shape=octagon,style="dashed, filled"];
-            0 -> 1 [style=dashed,arrowhead=none];
-            2 [label="CTF",shape=octagon,style="dashed, filled"];
-            0 -> 2 [style=dashed,arrowhead=none];
-            3 [label="hiddenMethod",shape=ellipse,style="dashed, filled"];
-            0 -> 3 [style=dashed,arrowhead=none];
-            4 [label="method",shape=ellipse,style="filled"];
-            5 [label="impl",shape=ellipse,style="dashed, filled"];
-            4 -> 5 [style=dashed,arrowhead=none];
-            0 -> 4 [style=dashed,arrowhead=none];
+            node_0 [label="Class",shape=house,style="filled"];
+            node_1 [label="CDF",shape=octagon,style="dashed, filled"];
+            "node_0" -> "node_1" [style=dashed,arrowhead=none];
+            node_2 [label="CTF",shape=octagon,style="dashed, filled"];
+            "node_0" -> "node_2" [style=dashed,arrowhead=none];
+            node_3 [label="hiddenMethod",shape=ellipse,style="dashed, filled"];
+            "node_0" -> "node_3" [style=dashed,arrowhead=none];
+            subgraph cluster_node_4 {
+                style=invis;
+                node_4 [label="method",shape=ellipse,style="filled"];
+                node_5 [label="impl",shape=ellipse,style="dashed, filled"];
+                "node_4" -> "node_5" [style=dashed,arrowhead=none];
+            }
+            "node_0" -> "node_4" [style=dashed,arrowhead=none];
         }
-        subgraph cluster_0_1 {
+        subgraph cluster_node_6 {
             style=invis;
-            6 [label="ExportedT",shape=octagon,style="filled"];
-            7 [label="Exported",shape=box,style="filled"];
-            6 -> 7 [style=dashed,arrowhead=none];
-            8 [label="NotExported",shape=box,style="dashed, filled"];
-            6 -> 8 [style=dashed,arrowhead=none];
-            9 [label="Single",shape=box,style="dashed, filled"];
-            6 -> 9 [style=dashed,arrowhead=none];
+            node_6 [label="ExportedT",shape=octagon,style="filled"];
+            node_7 [label="Exported",shape=box,style="filled"];
+            "node_6" -> "node_7" [style=dashed,arrowhead=none];
+            node_8 [label="NotExported",shape=box,style="dashed, filled"];
+            "node_6" -> "node_8" [style=dashed,arrowhead=none];
+            node_9 [label="Single",shape=box,style="dashed, filled"];
+            "node_6" -> "node_9" [style=dashed,arrowhead=none];
         }
-        subgraph cluster_0_2 {
+        subgraph cluster_node_10 {
             style=invis;
-            10 [label="GADT",shape=octagon,style="dashed, filled"];
-            11 [label="GADTFloat",shape=box,style="dashed, filled"];
-            10 -> 11 [style=dashed,arrowhead=none];
-            12 [label="GADTInt",shape=box,style="dashed, filled"];
-            10 -> 12 [style=dashed,arrowhead=none];
+            node_10 [label="GADT",shape=octagon,style="dashed, filled"];
+            node_11 [label="GADTFloat",shape=box,style="dashed, filled"];
+            "node_10" -> "node_11" [style=dashed,arrowhead=none];
+            node_12 [label="GADTInt",shape=box,style="dashed, filled"];
+            "node_10" -> "node_12" [style=dashed,arrowhead=none];
         }
-        subgraph cluster_0_3 {
+        subgraph cluster_node_13 {
             style=invis;
-            13 [label="LocalT",shape=octagon,style="dashed, filled"];
-            14 [label="Loc1",shape=box,style="dashed, filled"];
-            13 -> 14 [style=dashed,arrowhead=none];
-            15 [label="Loc2",shape=box,style="dashed, filled"];
-            13 -> 15 [style=dashed,arrowhead=none];
+            node_13 [label="LocalT",shape=octagon,style="dashed, filled"];
+            node_14 [label="Loc1",shape=box,style="dashed, filled"];
+            "node_13" -> "node_14" [style=dashed,arrowhead=none];
+            node_15 [label="Loc2",shape=box,style="dashed, filled"];
+            "node_13" -> "node_15" [style=dashed,arrowhead=none];
         }
-        subgraph cluster_0_4 {
+        subgraph cluster_node_16 {
             style=invis;
-            16 [label="Newtype",shape=octagon,style="dashed, filled"];
-            17 [label="Newtype",shape=box,style="dashed, filled"];
-            18 [label="accessor",shape=box,style="rounded, dashed, filled"];
-            17 -> 18 [style=dashed,arrowhead=none];
-            16 -> 17 [style=dashed,arrowhead=none];
+            node_16 [label="Newtype",shape=octagon,style="dashed, filled"];
+            subgraph cluster_node_17 {
+                style=invis;
+                node_17 [label="Newtype",shape=box,style="dashed, filled"];
+                node_18 [label="accessor",shape=box,style="rounded, dashed, filled"];
+                "node_17" -> "node_18" [style=dashed,arrowhead=none];
+            }
+            "node_16" -> "node_17" [style=dashed,arrowhead=none];
         }
-        subgraph cluster_0_5 {
+        subgraph cluster_node_19 {
             style=invis;
-            19 [label="Record",shape=octagon,style="dashed, filled"];
-            20 [label="NoRecord",shape=box,style="dashed, filled"];
-            19 -> 20 [style=dashed,arrowhead=none];
-            21 [label="Record1",shape=box,style="dashed, filled"];
-            22 [label="field1",shape=box,style="rounded, dashed, filled"];
-            21 -> 22 [style=dashed,arrowhead=none];
-            23 [label="field2",shape=box,style="rounded, dashed, filled"];
-            21 -> 23 [style=dashed,arrowhead=none];
-            24 [label="field3",shape=box,style="rounded, dashed, filled"];
-            21 -> 24 [style=dashed,arrowhead=none];
-            19 -> 21 [style=dashed,arrowhead=none];
-            25 [label="Record2",shape=box,style="dashed, filled"];
-            26 [label="field3",shape=box,style="rounded, dashed, filled"];
-            25 -> 26 [style=dashed,arrowhead=none];
-            19 -> 25 [style=dashed,arrowhead=none];
+            node_19 [label="Record",shape=octagon,style="dashed, filled"];
+            node_20 [label="NoRecord",shape=box,style="dashed, filled"];
+            "node_19" -> "node_20" [style=dashed,arrowhead=none];
+            subgraph cluster_node_21 {
+                style=invis;
+                node_21 [label="Record1",shape=box,style="dashed, filled"];
+                node_22 [label="field1",shape=box,style="rounded, dashed, filled"];
+                "node_21" -> "node_22" [style=dashed,arrowhead=none];
+                node_23 [label="field2",shape=box,style="rounded, dashed, filled"];
+                "node_21" -> "node_23" [style=dashed,arrowhead=none];
+                node_24 [label="field3",shape=box,style="rounded, dashed, filled"];
+                "node_21" -> "node_24" [style=dashed,arrowhead=none];
+            }
+            "node_19" -> "node_21" [style=dashed,arrowhead=none];
+            subgraph cluster_node_25 {
+                style=invis;
+                node_25 [label="Record2",shape=box,style="dashed, filled"];
+                node_26 [label="field3",shape=box,style="rounded, dashed, filled"];
+                "node_25" -> "node_26" [style=dashed,arrowhead=none];
+            }
+            "node_19" -> "node_25" [style=dashed,arrowhead=none];
         }
-        subgraph cluster_0_6 {
+        subgraph cluster_node_27 {
             style=invis;
-            27 [label="SubClass",shape=house,style="dashed, filled"];
-            28 [label="soup",shape=ellipse,style="dashed, filled"];
-            27 -> 28 [style=dashed,arrowhead=none];
+            node_27 [label="SubClass",shape=house,style="dashed, filled"];
+            node_28 [label="soup",shape=ellipse,style="dashed, filled"];
+            "node_27" -> "node_28" [style=dashed,arrowhead=none];
         }
-        subgraph cluster_0_7 {
+        node_29 [label="TypeFamily",shape=octagon,style="dashed, filled"];
+        node_30 [label="TypeSynonym",shape=octagon,style="filled"];
+        node_31 [label="WithSignature",shape=octagon,style="dashed, filled"];
+        node_32 [label="Zero",shape=octagon,style="dashed, filled"];
+        node_33 [label="emptyMap",shape=ellipse,style="dashed, filled"];
+        node_34 [label="expArg",shape=ellipse,style="dashed, filled"];
+        subgraph cluster_node_35 {
             style=invis;
-            29 [label="TypeFamily",shape=octagon,style="dashed, filled"];
+            node_35 [label="expValue",shape=ellipse,style="dashed, filled"];
+            node_36 [label="foo",shape=ellipse,style="dashed, filled"];
+            "node_35" -> "node_36" [style=dashed,arrowhead=none];
         }
-        subgraph cluster_0_8 {
+        subgraph cluster_node_37 {
             style=invis;
-            30 [label="TypeSynonym",shape=octagon,style="filled"];
+            node_37 [label="exportedFun",shape=ellipse,style="filled"];
+            node_38 [label="a",shape=ellipse,style="dashed, filled"];
+            "node_37" -> "node_38" [style=dashed,arrowhead=none];
+            node_39 [label="b",shape=ellipse,style="dashed, filled"];
+            "node_37" -> "node_39" [style=dashed,arrowhead=none];
         }
-        subgraph cluster_0_9 {
-            style=invis;
-            31 [label="WithSignature",shape=octagon,style="dashed, filled"];
-        }
-        subgraph cluster_0_10 {
-            style=invis;
-            32 [label="Zero",shape=octagon,style="dashed, filled"];
-        }
-        subgraph cluster_0_11 {
-            style=invis;
-            33 [label="emptyMap",shape=ellipse,style="dashed, filled"];
-        }
-        subgraph cluster_0_12 {
-            style=invis;
-            34 [label="expArg",shape=ellipse,style="dashed, filled"];
-        }
-        subgraph cluster_0_13 {
-            style=invis;
-            35 [label="expValue",shape=ellipse,style="dashed, filled"];
-            36 [label="foo",shape=ellipse,style="dashed, filled"];
-            35 -> 36 [style=dashed,arrowhead=none];
-        }
-        subgraph cluster_0_14 {
-            style=invis;
-            37 [label="exportedFun",shape=ellipse,style="filled"];
-            38 [label="a",shape=ellipse,style="dashed, filled"];
-            37 -> 38 [style=dashed,arrowhead=none];
-            39 [label="b",shape=ellipse,style="dashed, filled"];
-            37 -> 39 [style=dashed,arrowhead=none];
-        }
-        subgraph cluster_0_15 {
-            style=invis;
-            40 [label="localFun",shape=ellipse,style="dashed, filled"];
-        }
-        subgraph cluster_0_16 {
-            style=invis;
-            41 [label="recFn",shape=ellipse,style="dashed, filled"];
-        }
-        subgraph cluster_0_17 {
-            style=invis;
-            42 [label="untyped",shape=ellipse,style="dashed, filled"];
-        }
+        node_40 [label="localFun",shape=ellipse,style="dashed, filled"];
+        node_41 [label="recFn",shape=ellipse,style="dashed, filled"];
+        node_42 [label="untyped",shape=ellipse,style="dashed, filled"];
     }
-    5 -> 4 [dir=back];
-    13 -> 4 [dir=back];
-    15 -> 5 [dir=back];
-    10 -> 11 [dir=back];
-    13 -> 11 [dir=back];
-    10 -> 12 [dir=back];
-    19 -> 23 [dir=back];
-    0 -> 27 [dir=back];
-    15 -> 35 [dir=back];
-    36 -> 35 [dir=back];
-    14 -> 36 [dir=back];
-    15 -> 36 [dir=back];
-    38 -> 37 [dir=back];
-    39 -> 38 [dir=back];
-    38 -> 39 [dir=back];
-    3 -> 40 [dir=back];
-    20 -> 41 [dir=back];
-    21 -> 41 [dir=back];
-    22 -> 41 [dir=back];
-    23 -> 41 [dir=back];
-    26 -> 41 [dir=back];
-    9 -> 42 [dir=back];
+    "node_10" -> "node_11" [dir=back];
+    "node_13" -> "node_11" [dir=back];
+    "node_10" -> "node_12" [dir=back];
+    "node_19" -> "node_23" [dir=back];
+    "node_0" -> "node_27" [dir=back];
+    "node_15" -> "node_35" [dir=back];
+    "node_36" -> "node_35" [dir=back];
+    "node_14" -> "node_36" [dir=back];
+    "node_15" -> "node_36" [dir=back];
+    "node_38" -> "node_37" [dir=back];
+    "node_39" -> "node_38" [dir=back];
+    "node_38" -> "node_39" [dir=back];
+    "node_13" -> "node_4" [dir=back];
+    "node_5" -> "node_4" [dir=back];
+    "node_3" -> "node_40" [dir=back];
+    "node_20" -> "node_41" [dir=back];
+    "node_21" -> "node_41" [dir=back];
+    "node_22" -> "node_41" [dir=back];
+    "node_23" -> "node_41" [dir=back];
+    "node_26" -> "node_41" [dir=back];
+    "node_9" -> "node_42" [dir=back];
+    "node_15" -> "node_5" [dir=back];
 }


### PR DESCRIPTION
Split the rendering phase into two; one common, and one graphviz-specific.
As explained in the Haddock, the new `RenderGraph` is not actually all that different from the previous `CallGraph`.
Both GraphViz and Mermaid support the style of having a tree/hierarchy of nodes, and then listing a flat list of edges at the bottom, which was already very close to `Callgraph`.

My goal for this change was to make adding a new backend trivial. I think #24 took about 15 minutes to implement, so in that sense, this change is a success.