### PR TITLE
flake: refactor outputs.{apps -> packages}

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v19
       - name: nix build
-        run: nix build -L .#apps.x86_64-linux.calligraphyFor.${{ matrix.ghc }}
+        run: nix build -L .#calligraphyFor.${{ matrix.ghc }}
       - name: build shell
         run: nix build -L .#devShells.x86_64-linux.build-shells.${{ matrix.ghc }}
       - name: cabal build in shell

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
 
           pkgs = import inputs.nixpkgs { inherit system; overlays = [ overlay ]; };
 
-          mkApp = hspkgs: pkgs.haskell.lib.compose.justStaticExecutables hspkgs.calligraphy;
+          mkExe = hspkgs: pkgs.haskell.lib.compose.justStaticExecutables hspkgs.calligraphy;
 
           mkBuildShell = hspkgs:
             hspkgs.shellFor {
@@ -58,9 +58,7 @@
         in
         {
           packages.default = pkgs.calligraphy;
-
-          apps.default = pkgs.calligraphy;
-          apps.calligraphyFor = per-compiler mkApp;
+          packages.calligraphyFor = per-compiler mkExe;
 
           devShells.default = mkDevShell pkgs.haskellPackages;
           devShells.build-shells = per-compiler mkBuildShell;


### PR DESCRIPTION
We're not actually making proper flake apps, so better to declare as packages instead of apps.