### PR TITLE
Fix build on GHC 9.10

### DIFF
--- a/src/Calligraphy/Phases/Parse.hs
+++ b/src/Calligraphy/Phases/Parse.hs
@@ -102,7 +102,7 @@ ppLexTree = foldLexTree (pure ()) $ \ls l decl m r rs -> do
   rs
 
 ghcNameKey :: GHC.Name -> GHCKey
-ghcNameKey = GHCKey . GHC.getKey . GHC.nameUnique
+ghcNameKey = GHCKey . fromIntegral . GHC.getKey . GHC.nameUnique
 
 newtype ParsePhaseDebugInfo = ParsePhaseDebugInfo {modulesLexTrees :: [(String, LexTree Loc RawDecl)]}
 


### PR DESCRIPTION
The result type of `getKey` varies between an `Int` and a `Word`. Use `fromIntegral` to handle either.

Fixes #37.