### PR TITLE
GHC 9.10

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        resolver: [ nightly, lts-20, lts-19, lts-18, lts-17, lts-16, lts-15 ]
+        resolver: [ nightly, lts-23, lts-22, lts-21, lts-20, lts-19, lts-18, lts-17, lts-16, lts-15 ]
         # macos-13 is a workaround for https://github.com/haskell-actions/setup/issues/77
         os: [ macos-13, ubuntu-latest ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -40,7 +40,8 @@ jobs:
       fail-fast: false
       matrix:
         resolver: [ nightly, lts-20, lts-19, lts-18, lts-17, lts-16, lts-15 ]
-        os: [ macos-latest, ubuntu-latest ]
+        # macos-13 is a workaround for https://github.com/haskell-actions/setup/issues/77
+        os: [ macos-13, ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         ghc: [ '8.8.4', '8.10.7', '9.0.2', '9.2.8', '9.4.8', '9.6.6', '9.8.4', '9.10.1' ]
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-13 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,7 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [ ghc910, ghc98, ghc96, ghc94, ghc92, ghc90, ghc810, ghc88 ]
+        ghc: [ ghc910, ghc98, ghc96 ]
+        # GHC 9.4 and earlier have issues with the `unix` package that I don't feel like figuring out
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Nix default
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v19
       - run: nix build -L
       - run: nix develop -L -c echo "All good"
@@ -22,10 +22,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [ ghc8107, ghc902, ghc927, ghc945, ghc962 ]
+        ghc: [ ghc910, ghc98, ghc96, ghc94, ghc92, ghc90, ghc810, ghc88 ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v19
       - name: nix build
         run: nix build -L .#calligraphyFor.${{ matrix.ghc }}
@@ -43,8 +43,8 @@ jobs:
         os: [ macos-latest, ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: haskell/actions/setup@v2
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/setup@v2
         with:
           enable-stack: true
       - run: stack init --resolver ${{ matrix.resolver }}
@@ -57,12 +57,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [ '8.8.4', '8.10.7', '9.0.2', '9.2.7', '9.4.5', '9.6.2' ]
+        ghc: [ '8.8.4', '8.10.7', '9.0.2', '9.2.8', '9.4.8', '9.6.6', '9.8.4', '9.10.1' ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: haskell/actions/setup@v2
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
       - uses: actions/cache@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.7
+### [Added]
+- [#46] GHC 9.8, 9.10 support
+
 ## 0.1.6
 ### [Changed]
 - Internal change; partially undid the Prelude structure implemented in [#22] and [#27], since it was causing issues (see [#32])

--- a/calligraphy.cabal
+++ b/calligraphy.cabal
@@ -1,6 +1,6 @@
 cabal-version:   2.4
 name:            calligraphy
-version:         0.1.6
+version:         0.1.7
 license:         BSD-3-Clause
 build-type:      Simple
 license-file:    LICENSE
@@ -8,7 +8,14 @@ author:          Jonas Carpay
 maintainer:      Jonas Carpay <jonascarpay@gmail.com>
 copyright:       2022 Jonas Carpay
 tested-with:
-  GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.7 || ==9.4.5 || ==9.6.2
+  GHC ==8.8.4
+   || ==8.10.7
+   || ==9.0.2
+   || ==9.2.8
+   || ==9.4.8
+   || ==9.6.6
+   || ==9.8.4
+   || ==9.10.1
 
 extra-doc-files:
   CHANGELOG.md

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -17,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687441943,
-        "narHash": "sha256-WOth8mr8WMMwzab9D+JrPb08Ik9NaOvfozgkqi2aheA=",
+        "lastModified": 1744232197,
+        "narHash": "sha256-dGkTIwxR58w6DTiCV7AD/YlSZMz5en/IwnvW8mQq36A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0a49dd86e3fc1cee12dea55434686cb4d1e9fd41",
+        "rev": "300cf356fb3aca28d3d73bfd0276ddf6b21dd0c2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-23.05",
+        "ref": "release-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744232197,
-        "narHash": "sha256-dGkTIwxR58w6DTiCV7AD/YlSZMz5en/IwnvW8mQq36A=",
+        "lastModified": 1744280826,
+        "narHash": "sha256-LR68qPZYEKS9289drtH80bRlTKyjqCmUWxUUC9lOjmE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "300cf356fb3aca28d3d73bfd0276ddf6b21dd0c2",
+        "rev": "fdf470f39c25bed26250960a0d473175cfd10741",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "calligraphy";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-23.05";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-24.11";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = inputs:

--- a/flake.nix
+++ b/flake.nix
@@ -22,12 +22,14 @@
         let
 
           per-compiler = f: pkgs.lib.genAttrs [
-            "ghc962"
-            "ghc945"
-            "ghc927"
-            "ghc902"
-            "ghc8107"
-            "ghc884"
+            "ghc910"
+            "ghc98"
+            "ghc96"
+            "ghc94"
+            "ghc92"
+            "ghc90"
+            "ghc810"
+            "ghc88"
           ]
             (ghc: f pkgs.haskell.packages.${ghc});
 

--- a/src/Calligraphy/Phases/Parse.hs
+++ b/src/Calligraphy/Phases/Parse.hs
@@ -102,7 +102,7 @@ ppLexTree = foldLexTree (pure ()) $ \ls l decl m r rs -> do
   rs
 
 ghcNameKey :: GHC.Name -> GHCKey
-ghcNameKey = GHCKey . GHC.getKey . GHC.nameUnique
+ghcNameKey = GHCKey . fromIntegral . GHC.getKey . GHC.nameUnique
 
 newtype ParsePhaseDebugInfo = ParsePhaseDebugInfo {modulesLexTrees :: [(String, LexTree Loc RawDecl)]}
 


### PR DESCRIPTION
Fixes #37 
Fixes #40 

Subsumes #45 

- [x] Add GHC 9.8 and 9.10 to CI
- [x] Make CI green
- [x] Version bump
- [ ] Cut release
- [ ] Re-enable in stack