### PR TITLE
Compat with ghc 9.12+

### DIFF
--- a/src/Calligraphy/Compat/Debug.hs
+++ b/src/Calligraphy/Compat/Debug.hs
@@ -38,7 +38,7 @@ import qualified Unique as GHC
 #endif
 
 ppHieFile :: Prints GHC.HieFile
-ppHieFile (GHC.HieFile path (GHC.Module _ mdl) _types (GHC.HieASTs asts) _exps _src) = do
+ppHieFile GHC.HieFile{hie_hs_file=path, hie_module=GHC.Module _ mdl, hie_asts=GHC.HieASTs asts} = do
   strLn "Hie File"
   indent $ do
     strLn "path:"

--- a/src/Calligraphy/Phases/Parse.hs
+++ b/src/Calligraphy/Phases/Parse.hs
@@ -138,7 +138,7 @@ parseHieFiles files = (\(parsed, (_, keymap)) -> mkCallGraph parsed keymap) <$> 
        in (ParsePhaseDebugInfo debugs, CallGraph mods (rekeyCalls keymap (mconcat calls)) typeEdges)
 
 parseHieFile :: GHC.HieFile -> HieParse ParsedFile
-parseHieFile file@(GHC.HieFile filepath mdl _ _ avails _) = do
+parseHieFile file@GHC.HieFile{hie_hs_file=filepath,hie_module=mdl, hie_exports=avails} = do
   lextree <- either (throwError . TreeError modname filepath) pure $ structure decls
   let calls = resolveCalls (fmap (EnumSet.findMin . rdKeys) lextree)
   forest <- forestT (mkDecl exportKeys) (mkForest lextree)
@@ -205,7 +205,7 @@ data Collect = Collect
 
 -- | Collect declarations, uses, and types in a HIE file
 collect :: GHC.HieFile -> Collect
-collect (GHC.HieFile _ _ typeArr (GHC.HieASTs asts) _ _) = execState (forT_ traverse asts go) (Collect mempty mempty mempty)
+collect GHC.HieFile{hie_types=typeArr, hie_asts=GHC.HieASTs asts} = execState (forT_ traverse asts go) (Collect mempty mempty mempty)
   where
     tellDecl :: GHC.Name -> DeclType -> GHC.RealSrcSpan -> State Collect ()
     tellDecl nm typ spn = modify $ \(Collect decls uses types) -> Collect (decl : decls) uses types


### PR DESCRIPTION
I switched a few matches on `HieFile` to use record destructuring syntax, which should let the patterns be backward compatible to GHCs older than 9.12 which don't have the `hie_entity_infos` field.